### PR TITLE
Fargateのタスクを停止するLambda関数を実装する

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ clean:
 
 build: clean haltrds
 
+test:
+	go test -v ./...
+
 haltrds:
 	GOOS=linux GOARCH=amd64 go build -o bin/halt-rds ./halt-rds
 	chmod +x bin/halt-rds

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ STACK_NAME := dev-qiita-stocker-lambda
 clean:
 	rm -rf ./bin/halt-rds
 
-build: clean haltrds
+build: clean haltrds stopfg
 
 test:
 	go test -v ./...
@@ -15,6 +15,10 @@ test:
 haltrds:
 	GOOS=linux GOARCH=amd64 go build -o bin/halt-rds ./halt-rds
 	chmod +x bin/halt-rds
+
+stopfg:
+	GOOS=linux GOARCH=amd64 go build -o bin/stop-fargate ./stop-fargate
+	chmod +x bin/stop-fargate
 
 validate:
 	sam validate \

--- a/stop-fargate/app/ecsService.go
+++ b/stop-fargate/app/ecsService.go
@@ -1,0 +1,17 @@
+package app
+
+import (
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure"
+)
+
+func StopFargate(rep infrastructure.ECSRepository) {
+	for _, e := range targetECSs() {
+		rep.StopFargate(e)
+	}
+}
+
+func targetECSs() []infrastructure.ECS {
+	return []infrastructure.ECS{
+		{Cluster: "stg-fargate-api", Service: "stg-fargate-api"},
+	}
+}

--- a/stop-fargate/app/ecsService.go
+++ b/stop-fargate/app/ecsService.go
@@ -1,13 +1,27 @@
 package app
 
 import (
+	"errors"
+	"fmt"
+	"log"
+
 	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure"
 )
 
-func StopFargate(rep infrastructure.ECSRepository) {
+func StopFargate(rep infrastructure.ECSRepository) error {
+	errorCount := 0
 	for _, e := range targetECSs() {
-		rep.StopFargate(e)
+		if err := rep.StopFargate(e); err != nil {
+			log.Printf("failure to update service : %v", err)
+			log.Printf("cluster: %s, service: %s", e.Cluster, e.Service)
+			errorCount++
+		}
 	}
+
+	if errorCount != 0 {
+		return errors.New(fmt.Sprintf("failure to stop fargate"))
+	}
+	return nil
 }
 
 func targetECSs() []infrastructure.ECS {

--- a/stop-fargate/app/ecsService_test.go
+++ b/stop-fargate/app/ecsService_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure"
@@ -14,10 +15,20 @@ type mockECSClient struct {
 	ecsiface.ECSAPI
 }
 
+type mockErrorECSClient struct {
+	ecsiface.ECSAPI
+}
+
 func (m *mockECSClient) UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
 	output := &ecs.UpdateServiceOutput{}
 
 	return output, nil
+}
+
+func (m *mockErrorECSClient) UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+	output := &ecs.UpdateServiceOutput{}
+
+	return output, errors.New("")
 }
 
 func TestStopFargate(t *testing.T) {
@@ -25,6 +36,20 @@ func TestStopFargate(t *testing.T) {
 		c := &client.ECS{ECSAPI: &mockECSClient{}}
 		rdsRep := infrastructure.NewECSRepository(c)
 
-		StopFargate(rdsRep)
+		err := StopFargate(rdsRep)
+		if err != nil {
+			t.Errorf("error should not be returned")
+		}
 	})
+
+	t.Run("failure stop fargate", func(t *testing.T) {
+		c := &client.ECS{ECSAPI: &mockErrorECSClient{}}
+		rdsRep := infrastructure.NewECSRepository(c)
+
+		err := StopFargate(rdsRep)
+		if err == nil {
+			t.Errorf("error should not be returned")
+		}
+	})
+
 }

--- a/stop-fargate/app/ecsService_test.go
+++ b/stop-fargate/app/ecsService_test.go
@@ -1,0 +1,30 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure"
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure/client"
+
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+)
+
+type mockECSClient struct {
+	ecsiface.ECSAPI
+}
+
+func (m *mockECSClient) UpdateService(*ecs.UpdateServiceInput) (*ecs.UpdateServiceOutput, error) {
+	output := &ecs.UpdateServiceOutput{}
+
+	return output, nil
+}
+
+func TestStopFargate(t *testing.T) {
+	t.Run("success stop fargate", func(t *testing.T) {
+		c := &client.ECS{ECSAPI: &mockECSClient{}}
+		rdsRep := infrastructure.NewECSRepository(c)
+
+		StopFargate(rdsRep)
+	})
+}

--- a/stop-fargate/infrastructure/client/ecs.go
+++ b/stop-fargate/infrastructure/client/ecs.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/aws/aws-sdk-go/service/ecs/ecsiface"
+)
+
+type ECS struct {
+	ecsiface.ECSAPI
+}
+
+func NewECSClient() (*ECS, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String("ap-northeast-1")},
+	)
+	if err != nil {
+		return &ECS{}, err
+	}
+
+	return &ECS{
+		ECSAPI: ecs.New(sess),
+	}, nil
+}

--- a/stop-fargate/infrastructure/ecsRespository.go
+++ b/stop-fargate/infrastructure/ecsRespository.go
@@ -1,8 +1,6 @@
 package infrastructure
 
 import (
-	"log"
-
 	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure/client"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -15,7 +13,7 @@ type ECS struct {
 }
 
 type ECSRepository interface {
-	StopFargate(e ECS)
+	StopFargate(e ECS) error
 }
 
 type ecsRepository struct {
@@ -28,7 +26,7 @@ func NewECSRepository(c *client.ECS) ECSRepository {
 	}
 }
 
-func (e *ecsRepository) StopFargate(target ECS) {
+func (e *ecsRepository) StopFargate(target ECS) error {
 	input := ecs.UpdateServiceInput{
 		Cluster:      aws.String(target.Cluster),
 		Service:      aws.String(target.Service),
@@ -37,6 +35,7 @@ func (e *ecsRepository) StopFargate(target ECS) {
 
 	_, err := e.client.ECSAPI.UpdateService(&input)
 	if err != nil {
-		log.Printf("failer to update service: %v", err)
+		return err
 	}
+	return nil
 }

--- a/stop-fargate/infrastructure/ecsRespository.go
+++ b/stop-fargate/infrastructure/ecsRespository.go
@@ -1,0 +1,42 @@
+package infrastructure
+
+import (
+	"log"
+
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure/client"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+)
+
+type ECS struct {
+	Cluster string
+	Service string
+}
+
+type ECSRepository interface {
+	StopFargate(e ECS)
+}
+
+type ecsRepository struct {
+	client *client.ECS
+}
+
+func NewECSRepository(c *client.ECS) ECSRepository {
+	return &ecsRepository{
+		client: c,
+	}
+}
+
+func (e *ecsRepository) StopFargate(target ECS) {
+	input := ecs.UpdateServiceInput{
+		Cluster:      aws.String(target.Cluster),
+		Service:      aws.String(target.Service),
+		DesiredCount: aws.Int64(0),
+	}
+
+	_, err := e.client.ECSAPI.UpdateService(&input)
+	if err != nil {
+		log.Printf("failer to update service: %v", err)
+	}
+}

--- a/stop-fargate/main.go
+++ b/stop-fargate/main.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/app"
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure"
+	"github.com/nekochans/qiita-stocker-lambda/stop-fargate/infrastructure/client"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/aws/aws-lambda-go/lambda"
+)
+
+var (
+	rep infrastructure.ECSRepository
+)
+
+func init() {
+	client, err := client.NewECSClient()
+	if err != nil {
+		panic("failed initialize client: " + err.Error())
+	}
+	rep = infrastructure.NewECSRepository(client)
+}
+
+func handler(events.CloudWatchEvent) error {
+	app.StopFargate(rep)
+	return nil
+}
+
+func main() {
+	lambda.Start(handler)
+}

--- a/stop-fargate/main.go
+++ b/stop-fargate/main.go
@@ -22,7 +22,9 @@ func init() {
 }
 
 func handler(events.CloudWatchEvent) error {
-	app.StopFargate(rep)
+	if err := app.StopFargate(rep); err != nil {
+		return err
+	}
 	return nil
 }
 

--- a/template.yaml
+++ b/template.yaml
@@ -26,8 +26,34 @@ Resources:
           Properties:
             Schedule: cron(0 18 ? * * *)
 
+  StopFargateFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: bin/
+      Handler: stop-fargate
+      Runtime: go1.x
+      Tracing: Active
+      Policies:
+        - Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - ecs:UpdateService
+              Resource: '*'
+      Events:
+        StartScan:
+          Type: Schedule
+          Properties:
+            Schedule: cron(0 18 ? * * *)
+
   HaltRdsFuncLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${HaltRdsFunction}
+      RetentionInDays: 7
+
+  StopFargateFuncLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${StopFargateFunction}
       RetentionInDays: 7


### PR DESCRIPTION
# issueURL
https://github.com/nekochans/qiita-stocker-lambda/issues/4

# Doneの定義
https://github.com/nekochans/qiita-stocker-lambda/issues/4 の完了の定義が満たされていること

# 変更点概要

## 仕様的変更点概要
STG環境のFargateを日本時間の午前3時に停止する処理を作成。

## 技術的変更点概要
Fargateを停止する処理をLambda関数に追加。
RDSを停止する処理とは異なり、停止処理に失敗した場合はエラーを返す関数としている。
(RDSの場合は、RDSが停止済みの場合に`StopDBCluster`を実行すると必ずエラーになるため、エラーを返していない。)